### PR TITLE
Small refactor of sending nodedb to phone, removed 20ms delay, added …

### DIFF
--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -72,6 +72,7 @@ void PhoneAPI::handleStartConfig()
 
     LOG_INFO("Start API client config");
     nodeInfoForPhone.num = 0; // Don't keep returning old nodeinfos
+    nodeInfoQueue.clear();
     resetReadIndex();
 }
 
@@ -94,6 +95,7 @@ void PhoneAPI::close()
         fromRadioScratch = {};
         toRadioScratch = {};
         nodeInfoForPhone = {};
+        nodeInfoQueue.clear();
         packetForPhone = NULL;
         filesManifest.clear();
         fromRadioNum = 0;
@@ -432,19 +434,24 @@ size_t PhoneAPI::getFromRadio(uint8_t *buf)
 
     case STATE_SEND_OTHER_NODEINFOS: {
         LOG_DEBUG("Send known nodes");
+        if (nodeInfoForPhone.num == 0 && !nodeInfoQueue.empty()) {
+            // Pull the next prefetched entry so we can encode without touching flash during the read.
+            nodeInfoForPhone = nodeInfoQueue.front();
+            nodeInfoQueue.pop_front();
+        }
+
         if (nodeInfoForPhone.num != 0) {
-            // Just in case we stored a different user.id in the past, but should never happen going forward
             sprintf(nodeInfoForPhone.user.id, "!%08x", nodeInfoForPhone.num);
             LOG_INFO("nodeinfo: num=0x%x, lastseen=%u, id=%s, name=%s", nodeInfoForPhone.num, nodeInfoForPhone.last_heard,
                      nodeInfoForPhone.user.id, nodeInfoForPhone.user.long_name);
             fromRadioScratch.which_payload_variant = meshtastic_FromRadio_node_info_tag;
             fromRadioScratch.node_info = nodeInfoForPhone;
-            // Stay in current state until done sending nodeinfos
-            nodeInfoForPhone.num = 0; // We just consumed a nodeinfo, will need a new one next time
+            nodeInfoForPhone = {}; // mark consumed so the next read advances
+            prefetchNodeInfos();
         } else {
             LOG_DEBUG("Done sending nodeinfo");
+            nodeInfoQueue.clear();
             state = STATE_SEND_FILEMANIFEST;
-            // Go ahead and send that ID right now
             return getFromRadio(buf);
         }
         break;
@@ -546,6 +553,30 @@ void PhoneAPI::releaseQueueStatusPhonePacket()
     }
 }
 
+void PhoneAPI::prefetchNodeInfos()
+{
+    // Fill the local queue with a few converted records so BLE callbacks can respond immediately.
+    bool added = false;
+    while (nodeInfoQueue.size() < kNodePrefetchDepth) {
+        auto nextNode = nodeDB->readNextMeshNode(readIndex);
+        if (!nextNode)
+            break;
+
+        auto info = TypeConversions::ConvertToNodeInfo(nextNode);
+        bool isUs = info.num == nodeDB->getNodeNum();
+        info.hops_away = isUs ? 0 : info.hops_away;
+        info.last_heard = isUs ? getValidTime(RTCQualityFromNet) : info.last_heard;
+        info.snr = isUs ? 0 : info.snr;
+        info.via_mqtt = isUs ? false : info.via_mqtt;
+        info.is_favorite = info.is_favorite || isUs;
+        nodeInfoQueue.push_back(info);
+        added = true;
+    }
+
+    if (added)
+        onNowHasData(0);
+}
+
 void PhoneAPI::releaseMqttClientProxyPhonePacket()
 {
     if (mqttClientProxyMessageForPhone) {
@@ -582,19 +613,8 @@ bool PhoneAPI::available()
         return true;
 
     case STATE_SEND_OTHER_NODEINFOS:
-        if (nodeInfoForPhone.num == 0) {
-            auto nextNode = nodeDB->readNextMeshNode(readIndex);
-            if (nextNode) {
-                nodeInfoForPhone = TypeConversions::ConvertToNodeInfo(nextNode);
-                bool isUs = nodeInfoForPhone.num == nodeDB->getNodeNum();
-                nodeInfoForPhone.hops_away = isUs ? 0 : nodeInfoForPhone.hops_away;
-                nodeInfoForPhone.last_heard = isUs ? getValidTime(RTCQualityFromNet) : nodeInfoForPhone.last_heard;
-                nodeInfoForPhone.snr = isUs ? 0 : nodeInfoForPhone.snr;
-                nodeInfoForPhone.via_mqtt = isUs ? false : nodeInfoForPhone.via_mqtt;
-                nodeInfoForPhone.is_favorite = nodeInfoForPhone.is_favorite || isUs; // Our node is always a favorite
-                onNowHasData(0);
-            }
-        }
+        if (nodeInfoQueue.empty())
+            prefetchNodeInfos();
         return true; // Always say we have something, because we might need to advance our state machine
     case STATE_SEND_PACKETS: {
         if (!queueStatusPacketForPhone)

--- a/src/mesh/PhoneAPI.h
+++ b/src/mesh/PhoneAPI.h
@@ -3,6 +3,7 @@
 #include "Observer.h"
 #include "mesh-pb-constants.h"
 #include "meshtastic/portnums.pb.h"
+#include <deque>
 #include <iterator>
 #include <string>
 #include <unordered_map>
@@ -79,6 +80,10 @@ class PhoneAPI
 
     /// We temporarily keep the nodeInfo here between the call to available and getFromRadio
     meshtastic_NodeInfo nodeInfoForPhone = meshtastic_NodeInfo_init_default;
+    // Small cache of node info entries so BLE reads can be served immediately instead of waiting on DB access.
+    std::deque<meshtastic_NodeInfo> nodeInfoQueue;
+
+    static constexpr size_t kNodePrefetchDepth = 4;
 
     meshtastic_ToRadio toRadioScratch = {
         0}; // this is a static scratch object, any data must be copied elsewhere before returning
@@ -157,6 +162,8 @@ class PhoneAPI
     void releasePhonePacket();
 
     void releaseQueueStatusPhonePacket();
+
+    void prefetchNodeInfos();
 
     void releaseMqttClientProxyPhonePacket();
 


### PR DESCRIPTION
…ability to preload the next node to make the process faster.

## 🙏 Thank you for sending in a pull request, here's some tips to get started!

### ❌ (Please delete all these tips and replace them with your text) ❌

- Before starting on some new big chunk of code, it it is optional but highly recommended to open an issue first
  to say "Hey, I think this idea X should be implemented and I'm starting work on it. My general plan is Y, any feedback
  is appreciated." This will allow other devs to potentially save you time by not accidentially duplicating work etc...
- Please do not check in files that don't have real changes
- Please do not reformat lines that you didn't have to change the code on
- We recommend using the [Visual Studio Code](https://platformio.org/install/ide?install=vscode) editor along with the ['Trunk Check' extension](https://marketplace.visualstudio.com/items?itemName=trunk.io) (In beta for windows, WSL2 for the linux version),
  because it automatically follows our indentation rules and its auto reformatting will not cause spurious changes to lines.
- If your PR fixes a bug, mention "fixes #bugnum" somewhere in your pull request description.
- If your other co-developers have comments on your PR please tweak as needed.
- Please also enable "Allow edits by maintainers".
- Please do not submit untested code.
- If you do not have the affected hardware to test your code changes adequately against regressions, please indicate this, so that contributors and commnunity members can help test your changes.
- If your PR gets accepted you can request a "Contributor" role in the Meshtastic Discord

## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
