### PR TITLE
Add ShortUltra modem preset

### DIFF
--- a/mcp-server/src/meshtastic_mcp/server.py
+++ b/mcp-server/src/meshtastic_mcp/server.py
@@ -318,7 +318,7 @@ def userprefs_testing_profile(
         region: short code — one of US, EU_433, EU_868, CN, JP, ANZ, KR, TW,
             RU, IN, NZ_865, TH, UA_433, UA_868, MY_433, MY_919, SG_923, LORA_24.
         modem_preset: one of LONG_FAST, LONG_SLOW, LONG_MODERATE, VERY_LONG_SLOW,
-            MEDIUM_SLOW, MEDIUM_FAST, SHORT_SLOW, SHORT_FAST, SHORT_TURBO.
+            MEDIUM_SLOW, MEDIUM_FAST, SHORT_SLOW, SHORT_FAST, SHORT_TURBO, SHORT_ULTRA.
         short_name: optional owner short name (≤4 chars) stamped into the build.
         long_name: optional owner long name stamped into the build.
         disable_mqtt: disable MQTT module + uplink/downlink (default True).

--- a/mcp-server/src/meshtastic_mcp/userprefs.py
+++ b/mcp-server/src/meshtastic_mcp/userprefs.py
@@ -380,6 +380,7 @@ KNOWN_MODEM_PRESETS = {
     "SHORT_SLOW": "meshtastic_Config_LoRaConfig_ModemPreset_SHORT_SLOW",
     "SHORT_FAST": "meshtastic_Config_LoRaConfig_ModemPreset_SHORT_FAST",
     "SHORT_TURBO": "meshtastic_Config_LoRaConfig_ModemPreset_SHORT_TURBO",
+    "SHORT_ULTRA": "meshtastic_Config_LoRaConfig_ModemPreset_SHORT_ULTRA",
 }
 
 

--- a/src/DisplayFormatters.cpp
+++ b/src/DisplayFormatters.cpp
@@ -15,6 +15,9 @@ const char *DisplayFormatters::getModemPresetDisplayName(meshtastic_Config_LoRaC
     case PRESET(SHORT_TURBO):
         return useShortName ? "ShortT" : "ShortTurbo";
         break;
+    case PRESET(SHORT_ULTRA):
+        return useShortName ? "ShortU" : "ShortUltra";
+        break;
     case PRESET(SHORT_SLOW):
         return useShortName ? "ShortS" : "ShortSlow";
         break;

--- a/src/graphics/draw/MenuHandler.cpp
+++ b/src/graphics/draw/MenuHandler.cpp
@@ -474,13 +474,16 @@ static BannerOverlayOptions buildRegionPresetBanner()
 
     if (myRegion && myRegion->profile) {
         const meshtastic_Config_LoRaConfig_ModemPreset *presets = myRegion->getAvailablePresets();
-        size_t numPresets = myRegion->getNumPresets();
-        for (size_t i = 0; i < numPresets && count < MAX_PRESET_OPTIONS; ++i) {
-            const char *name = DisplayFormatters::getModemPresetDisplayName(presets[i], false, true);
+        for (size_t i = 0; presets[i] != MODEM_PRESET_END && count < MAX_PRESET_OPTIONS; ++i) {
+            const auto preset = presets[i];
+            if (!myRegion->supportsPreset(preset))
+                continue;
+
+            const char *name = DisplayFormatters::getModemPresetDisplayName(preset, false, true);
             strncpy(presetLabelBuf[count], name, sizeof(presetLabelBuf[count]) - 1);
             presetLabelBuf[count][sizeof(presetLabelBuf[count]) - 1] = '\0';
             optionsArray[count] = presetLabelBuf[count];
-            optionsEnumArray[count++] = static_cast<int>(presets[i]);
+            optionsEnumArray[count++] = static_cast<int>(preset);
         }
     }
 

--- a/src/graphics/niche/InkHUD/Applets/System/Menu/MenuApplet.cpp
+++ b/src/graphics/niche/InkHUD/Applets/System/Menu/MenuApplet.cpp
@@ -1559,10 +1559,13 @@ void InkHUD::MenuApplet::showPage(MenuPage page)
         regionPresetCount = 0;
         if (myRegion && myRegion->profile) {
             const meshtastic_Config_LoRaConfig_ModemPreset *presets = myRegion->getAvailablePresets();
-            size_t numPresets = myRegion->getNumPresets();
-            for (size_t i = 0; i < numPresets && regionPresetCount < MAX_REGION_PRESETS; ++i) {
-                regionPresets[regionPresetCount++] = presets[i];
-                const char *name = DisplayFormatters::getModemPresetDisplayName(presets[i], false, true);
+            for (size_t i = 0; presets[i] != MODEM_PRESET_END && regionPresetCount < MAX_REGION_PRESETS; ++i) {
+                const auto preset = presets[i];
+                if (!myRegion->supportsPreset(preset))
+                    continue;
+
+                regionPresets[regionPresetCount++] = preset;
+                const char *name = DisplayFormatters::getModemPresetDisplayName(preset, false, true);
                 nodeConfigLabels.emplace_back(name);
                 items.push_back(MenuItem(nodeConfigLabels.back().c_str(), MenuAction::SET_PRESET_FROM_REGION, MenuPage::EXIT));
             }

--- a/src/mesh/MeshRadio.h
+++ b/src/mesh/MeshRadio.h
@@ -15,6 +15,18 @@ static const meshtastic_Config_LoRaConfig_ModemPreset MODEM_PRESET_END =
 
 #define PRESET(name) meshtastic_Config_LoRaConfig_ModemPreset_##name
 
+static inline bool modemPresetRadioCompatible(meshtastic_Config_LoRaConfig_ModemPreset preset, bool wideLoraRegion)
+{
+    if (preset != PRESET(SHORT_ULTRA))
+        return true;
+
+    if (wideLoraRegion)
+        return false;
+
+    return radioType == SX1262_RADIO || radioType == SX1268_RADIO || radioType == LR1110_RADIO || radioType == LR1120_RADIO ||
+           radioType == LR1121_RADIO;
+}
+
 // Override slot magic numbers for RegionInfo.overrideSlot
 #define OVERRIDE_SLOT_DEFAULT_CHANNEL_HASH 0 // Use hash of primary channel name
 #define OVERRIDE_SLOT_PRESET_HASH -1         // Use hash of preset name instead
@@ -69,15 +81,17 @@ struct RegionInfo {
     {
         for (size_t i = 0; profile->presets[i] != MODEM_PRESET_END; i++) {
             if (profile->presets[i] == preset)
-                return true;
+                return modemPresetRadioCompatible(preset, wideLora);
         }
         return false;
     }
     size_t getNumPresets() const
     {
         size_t n = 0;
-        while (profile->presets[n] != MODEM_PRESET_END)
-            n++;
+        for (size_t i = 0; profile->presets[i] != MODEM_PRESET_END; i++) {
+            if (modemPresetRadioCompatible(profile->presets[i], wideLora))
+                n++;
+        }
         return n;
     }
 };
@@ -194,6 +208,11 @@ static inline void modemPresetToParams(meshtastic_Config_LoRaConfig_ModemPreset 
                                        uint8_t &cr)
 {
     switch (preset) {
+    case PRESET(SHORT_ULTRA):
+        bwKHz = 500.0f;
+        cr = 5;
+        sf = 5;
+        break;
     case PRESET(SHORT_TURBO):
         bwKHz = wideLora ? 1625.0f : 500.0f;
         cr = 5;

--- a/src/mesh/MeshRadio.h
+++ b/src/mesh/MeshRadio.h
@@ -15,7 +15,8 @@ static const meshtastic_Config_LoRaConfig_ModemPreset MODEM_PRESET_END =
 
 #define PRESET(name) meshtastic_Config_LoRaConfig_ModemPreset_##name
 
-static inline bool modemPresetRadioCompatible(meshtastic_Config_LoRaConfig_ModemPreset preset, bool wideLoraRegion)
+static inline bool modemPresetRadioCompatible(meshtastic_Config_LoRaConfig_ModemPreset preset, bool wideLoraRegion,
+                                              bool allowUnknownRadio = false)
 {
     if (preset != PRESET(SHORT_ULTRA))
         return true;
@@ -23,8 +24,8 @@ static inline bool modemPresetRadioCompatible(meshtastic_Config_LoRaConfig_Modem
     if (wideLoraRegion)
         return false;
 
-    return radioType == SX1262_RADIO || radioType == SX1268_RADIO || radioType == LR1110_RADIO || radioType == LR1120_RADIO ||
-           radioType == LR1121_RADIO;
+    return (allowUnknownRadio && radioType == NO_RADIO) || radioType == STM32WLx_RADIO || radioType == SX1262_RADIO ||
+           radioType == SX1268_RADIO || radioType == LR1110_RADIO || radioType == LR1120_RADIO || radioType == LR1121_RADIO;
 }
 
 // Override slot magic numbers for RegionInfo.overrideSlot
@@ -77,19 +78,19 @@ struct RegionInfo {
     // Preset accessors (delegate through profile)
     meshtastic_Config_LoRaConfig_ModemPreset getDefaultPreset() const { return defaultPreset; }
     const meshtastic_Config_LoRaConfig_ModemPreset *getAvailablePresets() const { return profile->presets; }
-    bool supportsPreset(meshtastic_Config_LoRaConfig_ModemPreset preset) const
+    bool supportsPreset(meshtastic_Config_LoRaConfig_ModemPreset preset, bool allowUnknownRadio = false) const
     {
         for (size_t i = 0; profile->presets[i] != MODEM_PRESET_END; i++) {
             if (profile->presets[i] == preset)
-                return modemPresetRadioCompatible(preset, wideLora);
+                return modemPresetRadioCompatible(preset, wideLora, allowUnknownRadio);
         }
         return false;
     }
-    size_t getNumPresets() const
+    size_t getNumPresets(bool allowUnknownRadio = false) const
     {
         size_t n = 0;
         for (size_t i = 0; profile->presets[i] != MODEM_PRESET_END; i++) {
-            if (modemPresetRadioCompatible(profile->presets[i], wideLora))
+            if (modemPresetRadioCompatible(profile->presets[i], wideLora, allowUnknownRadio))
                 n++;
         }
         return n;

--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -657,14 +657,14 @@ const RegionInfo *getRegion(meshtastic_Config_LoRaConfig_RegionCode code)
     return r;
 }
 
-static bool presetGroupMatchesRegion(const meshtastic_LoRaPresetGroup &grp, const RegionInfo *r)
+static bool presetGroupMatchesRegion(const meshtastic_LoRaPresetGroup &grp, const RegionInfo *r, bool allowUnknownRadio)
 {
     if (grp.default_preset != r->getDefaultPreset() || grp.licensed_only != r->profile->licensedOnly)
         return false;
 
     pb_size_t p = 0;
     for (size_t i = 0; r->profile->presets[i] != MODEM_PRESET_END; i++) {
-        if (!r->supportsPreset(r->profile->presets[i]))
+        if (!r->supportsPreset(r->profile->presets[i], allowUnknownRadio))
             continue;
         if (p >= grp.presets_count || grp.presets[p] != r->profile->presets[i])
             return false;
@@ -681,6 +681,9 @@ void getRegionPresetMap(meshtastic_LoRaRegionPresetMap &map)
     const size_t maxGroups = sizeof(map.groups) / sizeof(map.groups[0]);
     const size_t maxRegions = sizeof(map.region_groups) / sizeof(map.region_groups[0]);
     const size_t maxPresets = sizeof(map.groups[0].presets) / sizeof(map.groups[0].presets[0]);
+
+    // If radio probing has not finished, do not hide presets that may become valid.
+    const bool allowUnknownRadio = true;
 
     // Coalesce regions that share an identical preset list into one group. Two
     // regions belong to the same group when they share the same RegionProfile
@@ -702,7 +705,7 @@ void getRegionPresetMap(meshtastic_LoRaRegionPresetMap &map)
         // Find the group this region belongs to, or create it.
         int gi = -1;
         for (pb_size_t g = 0; g < map.groups_count; g++) {
-            if (groupProfile[g] == r->profile && presetGroupMatchesRegion(map.groups[g], r)) {
+            if (groupProfile[g] == r->profile && presetGroupMatchesRegion(map.groups[g], r, allowUnknownRadio)) {
                 gi = g;
                 break;
             }
@@ -721,7 +724,7 @@ void getRegionPresetMap(meshtastic_LoRaRegionPresetMap &map)
             grp.licensed_only = r->profile->licensedOnly;
             grp.presets_count = 0;
             for (size_t i = 0; r->profile->presets[i] != MODEM_PRESET_END && grp.presets_count < maxPresets; i++) {
-                if (r->supportsPreset(r->profile->presets[i]))
+                if (r->supportsPreset(r->profile->presets[i], allowUnknownRadio))
                     grp.presets[grp.presets_count++] = r->profile->presets[i];
             }
         }

--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -35,8 +35,8 @@
 #endif
 
 static const meshtastic_Config_LoRaConfig_ModemPreset PRESETS_STD[] = {
-    PRESET(LONG_FAST),  PRESET(LONG_SLOW),     PRESET(MEDIUM_SLOW), PRESET(MEDIUM_FAST), PRESET(SHORT_SLOW),
-    PRESET(SHORT_FAST), PRESET(LONG_MODERATE), PRESET(SHORT_TURBO), PRESET(LONG_TURBO),  MODEM_PRESET_END};
+    PRESET(LONG_FAST),     PRESET(LONG_SLOW),   PRESET(MEDIUM_SLOW), PRESET(MEDIUM_FAST), PRESET(SHORT_SLOW), PRESET(SHORT_FAST),
+    PRESET(LONG_MODERATE), PRESET(SHORT_TURBO), PRESET(LONG_TURBO),  PRESET(SHORT_ULTRA), MODEM_PRESET_END};
 
 static const meshtastic_Config_LoRaConfig_ModemPreset PRESETS_EU_868[] = {
     PRESET(LONG_FAST),  PRESET(LONG_SLOW),  PRESET(MEDIUM_SLOW),   PRESET(MEDIUM_FAST),
@@ -309,9 +309,23 @@ extern RadioLibHal *RadioLibHAL;
 extern SPIClass SPI1;
 #endif
 
+static void clearRadioTypeOnFailedProbe()
+{
+    radioType = NO_RADIO;
+}
+
 std::unique_ptr<RadioInterface> initLoRa()
 {
     std::unique_ptr<RadioInterface> rIf = nullptr;
+    meshtastic_Config_LoRaConfig loraBeforeProbe = config.lora;
+    auto beginProbe = [&](LoRaRadioType candidate) {
+        loraBeforeProbe = config.lora;
+        radioType = candidate;
+    };
+    auto failProbe = [&]() {
+        config.lora = loraBeforeProbe;
+        clearRadioTypeOnFailedProbe();
+    };
 
 #if ARCH_PORTDUINO
     SPISettings loraSpiSettings(portduino_config.spiSpeed, MSBFIRST, SPI_MODE0);
@@ -321,6 +335,30 @@ std::unique_ptr<RadioInterface> initLoRa()
 
 #ifdef ARCH_PORTDUINO
     // as one can't use a function pointer to the class constructor:
+    auto portduinoRadioType = [](lora_module_enum module) {
+        switch (module) {
+        case use_rf95:
+            return RF95_RADIO;
+        case use_sx1262:
+            return SX1262_RADIO;
+        case use_sx1268:
+            return SX1268_RADIO;
+        case use_sx1280:
+            return SX1280_RADIO;
+        case use_lr1110:
+            return LR1110_RADIO;
+        case use_lr1120:
+            return LR1120_RADIO;
+        case use_lr1121:
+            return LR1121_RADIO;
+        case use_llcc68:
+            return LLCC68_RADIO;
+        case use_simradio:
+            return SIM_RADIO;
+        default:
+            return NO_RADIO;
+        }
+    };
     auto loraModuleInterface = [](LockingArduinoHal *hal, RADIOLIB_PIN_TYPE cs, RADIOLIB_PIN_TYPE irq, RADIOLIB_PIN_TYPE rst,
                                   RADIOLIB_PIN_TYPE busy) {
         switch (portduino_config.lora_module) {
@@ -363,6 +401,7 @@ std::unique_ptr<RadioInterface> initLoRa()
         loraModuleInterface((LockingArduinoHal *)RadioLibHAL, portduino_config.lora_cs_pin.pin, portduino_config.lora_irq_pin.pin,
                             portduino_config.lora_reset_pin.pin, portduino_config.lora_busy_pin.pin);
 
+    beginProbe(portduinoRadioType(portduino_config.lora_module));
     if (!rIf->init()) {
         LOG_WARN("No %s radio", portduino_config.loraModules[portduino_config.lora_module].c_str());
         rIf = nullptr;
@@ -384,12 +423,13 @@ std::unique_ptr<RadioInterface> initLoRa()
     if (!rIf) {
         rIf = std::unique_ptr<STM32WLE5JCInterface>(
             new STM32WLE5JCInterface(loraHal, SX126X_CS, SX126X_DIO1, SX126X_RESET, SX126X_BUSY));
+        beginProbe(STM32WLx_RADIO);
         if (!rIf->init()) {
             LOG_WARN("No STM32WL radio");
             rIf = nullptr;
+            failProbe();
         } else {
             LOG_INFO("STM32WL init success");
-            radioType = STM32WLx_RADIO;
         }
     }
 #endif
@@ -397,12 +437,13 @@ std::unique_ptr<RadioInterface> initLoRa()
 #if defined(RF95_IRQ) && RADIOLIB_EXCLUDE_SX127X != 1
     if ((!rIf) && (config.lora.region != meshtastic_Config_LoRaConfig_RegionCode_LORA_24)) {
         rIf = std::unique_ptr<RF95Interface>(new RF95Interface(loraHal, LORA_CS, RF95_IRQ, RF95_RESET, RF95_DIO1));
+        beginProbe(RF95_RADIO);
         if (!rIf->init()) {
             LOG_WARN("No RF95 radio");
             rIf = nullptr;
+            failProbe();
         } else {
             LOG_INFO("RF95 init success");
-            radioType = RF95_RADIO;
         }
     }
 #endif
@@ -414,13 +455,14 @@ std::unique_ptr<RadioInterface> initLoRa()
 #ifdef SX126X_DIO3_TCXO_VOLTAGE
         sxIf->setTCXOVoltage(SX126X_DIO3_TCXO_VOLTAGE);
 #endif
+        beginProbe(SX1262_RADIO);
         if (!sxIf->init()) {
             LOG_WARN("No SX1262 radio");
             rIf = nullptr;
+            failProbe();
         } else {
             LOG_INFO("SX1262 init success");
             rIf = std::move(sxIf);
-            radioType = SX1262_RADIO;
         }
     }
 #endif
@@ -431,25 +473,27 @@ std::unique_ptr<RadioInterface> initLoRa()
         auto sxIf =
             std::unique_ptr<SX1262Interface>(new SX1262Interface(loraHal, SX126X_CS, SX126X_DIO1, SX126X_RESET, SX126X_BUSY));
         sxIf->setTCXOVoltage(SX126X_DIO3_TCXO_VOLTAGE);
+        beginProbe(SX1262_RADIO);
         if (!sxIf->init()) {
             LOG_WARN("No SX1262 radio with TCXO, Vref %fV", SX126X_DIO3_TCXO_VOLTAGE);
             rIf = nullptr;
+            failProbe();
         } else {
             LOG_INFO("SX1262 init success, TCXO, Vref %fV", SX126X_DIO3_TCXO_VOLTAGE);
             rIf = std::move(sxIf);
-            radioType = SX1262_RADIO;
         }
     }
 
     if ((!rIf) && (config.lora.region != meshtastic_Config_LoRaConfig_RegionCode_LORA_24)) {
         // If specified TCXO voltage fails, attempt to use DIO3 as a reference instead
         rIf = std::unique_ptr<SX1262Interface>(new SX1262Interface(loraHal, SX126X_CS, SX126X_DIO1, SX126X_RESET, SX126X_BUSY));
+        beginProbe(SX1262_RADIO);
         if (!rIf->init()) {
             LOG_WARN("No SX1262 radio with XTAL, Vref 0.0V");
             rIf = nullptr;
+            failProbe();
         } else {
             LOG_INFO("SX1262 init success, XTAL, Vref 0.0V");
-            radioType = SX1262_RADIO;
         }
     }
 #endif
@@ -461,24 +505,26 @@ std::unique_ptr<RadioInterface> initLoRa()
         auto sxIf =
             std::unique_ptr<SX1268Interface>(new SX1268Interface(loraHal, SX126X_CS, SX126X_DIO1, SX126X_RESET, SX126X_BUSY));
         sxIf->setTCXOVoltage(SX126X_DIO3_TCXO_VOLTAGE);
+        beginProbe(SX1268_RADIO);
         if (!sxIf->init()) {
             LOG_WARN("No SX1268 radio with TCXO, Vref %fV", SX126X_DIO3_TCXO_VOLTAGE);
             rIf = nullptr;
+            failProbe();
         } else {
             LOG_INFO("SX1268 init success, TCXO, Vref %fV", SX126X_DIO3_TCXO_VOLTAGE);
             rIf = std::move(sxIf);
-            radioType = SX1268_RADIO;
         }
     }
 #endif
     if ((!rIf) && (config.lora.region != meshtastic_Config_LoRaConfig_RegionCode_LORA_24)) {
         rIf = std::unique_ptr<SX1268Interface>(new SX1268Interface(loraHal, SX126X_CS, SX126X_DIO1, SX126X_RESET, SX126X_BUSY));
+        beginProbe(SX1268_RADIO);
         if (!rIf->init()) {
             LOG_WARN("No SX1268 radio");
             rIf = nullptr;
+            failProbe();
         } else {
             LOG_INFO("SX1268 init success");
-            radioType = SX1268_RADIO;
         }
     }
 #endif
@@ -486,12 +532,13 @@ std::unique_ptr<RadioInterface> initLoRa()
 #if defined(USE_LLCC68)
     if ((!rIf) && (config.lora.region != meshtastic_Config_LoRaConfig_RegionCode_LORA_24)) {
         rIf = std::unique_ptr<LLCC68Interface>(new LLCC68Interface(loraHal, SX126X_CS, SX126X_DIO1, SX126X_RESET, SX126X_BUSY));
+        beginProbe(LLCC68_RADIO);
         if (!rIf->init()) {
             LOG_WARN("No LLCC68 radio");
             rIf = nullptr;
+            failProbe();
         } else {
             LOG_INFO("LLCC68 init success");
-            radioType = LLCC68_RADIO;
         }
     }
 #endif
@@ -500,12 +547,13 @@ std::unique_ptr<RadioInterface> initLoRa()
     if ((!rIf) && (config.lora.region != meshtastic_Config_LoRaConfig_RegionCode_LORA_24)) {
         rIf = std::unique_ptr<LR1110Interface>(
             new LR1110Interface(loraHal, LR1110_SPI_NSS_PIN, LR1110_IRQ_PIN, LR1110_NRESET_PIN, LR1110_BUSY_PIN));
+        beginProbe(LR1110_RADIO);
         if (!rIf->init()) {
             LOG_WARN("No LR1110 radio");
             rIf = nullptr;
+            failProbe();
         } else {
             LOG_INFO("LR1110 init success");
-            radioType = LR1110_RADIO;
         }
     }
 #endif
@@ -514,12 +562,13 @@ std::unique_ptr<RadioInterface> initLoRa()
     if (!rIf) {
         rIf = std::unique_ptr<LR1120Interface>(
             new LR1120Interface(loraHal, LR1120_SPI_NSS_PIN, LR1120_IRQ_PIN, LR1120_NRESET_PIN, LR1120_BUSY_PIN));
+        beginProbe(LR1120_RADIO);
         if (!rIf->init()) {
             LOG_WARN("No LR1120 radio");
             rIf = nullptr;
+            failProbe();
         } else {
             LOG_INFO("LR1120 init success");
-            radioType = LR1120_RADIO;
         }
     }
 #endif
@@ -528,12 +577,13 @@ std::unique_ptr<RadioInterface> initLoRa()
     if (!rIf) {
         rIf = std::unique_ptr<LR1121Interface>(
             new LR1121Interface(loraHal, LR1121_SPI_NSS_PIN, LR1121_IRQ_PIN, LR1121_NRESET_PIN, LR1121_BUSY_PIN));
+        beginProbe(LR1121_RADIO);
         if (!rIf->init()) {
             LOG_WARN("No LR1121 radio");
             rIf = nullptr;
+            failProbe();
         } else {
             LOG_INFO("LR1121 init success");
-            radioType = LR1121_RADIO;
         }
     }
 #endif
@@ -542,12 +592,13 @@ std::unique_ptr<RadioInterface> initLoRa()
     if (!rIf) {
         rIf = std::unique_ptr<LR2021Interface>(
             new LR2021Interface(loraHal, LR2021_SPI_NSS_PIN, LR2021_IRQ_PIN, LR2021_NRESET_PIN, LR2021_BUSY_PIN));
+        beginProbe(LR2021_RADIO);
         if (!rIf->init()) {
             LOG_WARN("No LR2021 radio");
             rIf = nullptr;
+            failProbe();
         } else {
             LOG_INFO("LR2021 init success");
-            radioType = LR2021_RADIO;
         }
     }
 #endif
@@ -555,12 +606,13 @@ std::unique_ptr<RadioInterface> initLoRa()
 #if defined(USE_SX1280) && RADIOLIB_EXCLUDE_SX128X != 1
     if (!rIf) {
         rIf = std::unique_ptr<SX1280Interface>(new SX1280Interface(loraHal, SX128X_CS, SX128X_DIO1, SX128X_RESET, SX128X_BUSY));
+        beginProbe(SX1280_RADIO);
         if (!rIf->init()) {
             LOG_WARN("No SX1280 radio");
             rIf = nullptr;
+            failProbe();
         } else {
             LOG_INFO("SX1280 init success");
-            radioType = SX1280_RADIO;
         }
     }
 #endif
@@ -605,6 +657,23 @@ const RegionInfo *getRegion(meshtastic_Config_LoRaConfig_RegionCode code)
     return r;
 }
 
+static bool presetGroupMatchesRegion(const meshtastic_LoRaPresetGroup &grp, const RegionInfo *r)
+{
+    if (grp.default_preset != r->getDefaultPreset() || grp.licensed_only != r->profile->licensedOnly)
+        return false;
+
+    pb_size_t p = 0;
+    for (size_t i = 0; r->profile->presets[i] != MODEM_PRESET_END; i++) {
+        if (!r->supportsPreset(r->profile->presets[i]))
+            continue;
+        if (p >= grp.presets_count || grp.presets[p] != r->profile->presets[i])
+            return false;
+        p++;
+    }
+
+    return p == grp.presets_count;
+}
+
 void getRegionPresetMap(meshtastic_LoRaRegionPresetMap &map)
 {
     map = meshtastic_LoRaRegionPresetMap_init_zero;
@@ -615,7 +684,8 @@ void getRegionPresetMap(meshtastic_LoRaRegionPresetMap &map)
 
     // Coalesce regions that share an identical preset list into one group. Two
     // regions belong to the same group when they share the same RegionProfile
-    // (which owns the preset list + licensing) AND the same default preset.
+    // (which owns the base preset list + licensing), the same default preset, and
+    // the same compatibility-filtered preset list.
     // Keyed by profile pointer, not the preset-array pointer: PROFILE_NARROW and
     // PROFILE_HAM_100KHZ share PRESETS_NARROW but differ in licensedOnly.
     const RegionProfile *groupProfile[sizeof(map.groups) / sizeof(map.groups[0])] = {};
@@ -632,7 +702,7 @@ void getRegionPresetMap(meshtastic_LoRaRegionPresetMap &map)
         // Find the group this region belongs to, or create it.
         int gi = -1;
         for (pb_size_t g = 0; g < map.groups_count; g++) {
-            if (groupProfile[g] == r->profile && map.groups[g].default_preset == r->getDefaultPreset()) {
+            if (groupProfile[g] == r->profile && presetGroupMatchesRegion(map.groups[g], r)) {
                 gi = g;
                 break;
             }
@@ -650,8 +720,10 @@ void getRegionPresetMap(meshtastic_LoRaRegionPresetMap &map)
             grp.default_preset = r->getDefaultPreset();
             grp.licensed_only = r->profile->licensedOnly;
             grp.presets_count = 0;
-            for (size_t i = 0; r->profile->presets[i] != MODEM_PRESET_END && grp.presets_count < maxPresets; i++)
-                grp.presets[grp.presets_count++] = r->profile->presets[i];
+            for (size_t i = 0; r->profile->presets[i] != MODEM_PRESET_END && grp.presets_count < maxPresets; i++) {
+                if (r->supportsPreset(r->profile->presets[i]))
+                    grp.presets[grp.presets_count++] = r->profile->presets[i];
+            }
         }
 
         // Map this region to its group (capacity checked at the top of the loop).

--- a/src/mesh/generated/meshtastic/config.pb.h
+++ b/src/mesh/generated/meshtastic/config.pb.h
@@ -374,7 +374,12 @@ typedef enum _meshtastic_Config_LoRaConfig_ModemPreset {
  Note: TCXO with tight tolerances (±5 ppm or better) is *absolutely required* at these narrow bandwidths.
  Only compatible with SX127x and SX126x chipsets.
  Comparable link budget and data rate to LONG_MODERATE. */
-    meshtastic_Config_LoRaConfig_ModemPreset_TINY_SLOW = 15
+    meshtastic_Config_LoRaConfig_ModemPreset_TINY_SLOW = 15,
+    /* Short Range - Ultra
+ Fastest preset with 500kHz bandwidth, SF5, and CR 4/5.
+ Intended data rate is about 62.5 kbps.
+ Only compatible with SX126x and LR11xx chipsets. */
+    meshtastic_Config_LoRaConfig_ModemPreset_SHORT_ULTRA = 16
 } meshtastic_Config_LoRaConfig_ModemPreset;
 
 typedef enum _meshtastic_Config_LoRaConfig_FEM_LNA_Mode {
@@ -767,8 +772,8 @@ extern "C" {
 #define _meshtastic_Config_LoRaConfig_RegionCode_ARRAYSIZE ((meshtastic_Config_LoRaConfig_RegionCode)(meshtastic_Config_LoRaConfig_RegionCode_ITU2_125CM+1))
 
 #define _meshtastic_Config_LoRaConfig_ModemPreset_MIN meshtastic_Config_LoRaConfig_ModemPreset_LONG_FAST
-#define _meshtastic_Config_LoRaConfig_ModemPreset_MAX meshtastic_Config_LoRaConfig_ModemPreset_TINY_SLOW
-#define _meshtastic_Config_LoRaConfig_ModemPreset_ARRAYSIZE ((meshtastic_Config_LoRaConfig_ModemPreset)(meshtastic_Config_LoRaConfig_ModemPreset_TINY_SLOW+1))
+#define _meshtastic_Config_LoRaConfig_ModemPreset_MAX meshtastic_Config_LoRaConfig_ModemPreset_SHORT_ULTRA
+#define _meshtastic_Config_LoRaConfig_ModemPreset_ARRAYSIZE ((meshtastic_Config_LoRaConfig_ModemPreset)(meshtastic_Config_LoRaConfig_ModemPreset_SHORT_ULTRA+1))
 
 #define _meshtastic_Config_LoRaConfig_FEM_LNA_Mode_MIN meshtastic_Config_LoRaConfig_FEM_LNA_Mode_DISABLED
 #define _meshtastic_Config_LoRaConfig_FEM_LNA_Mode_MAX meshtastic_Config_LoRaConfig_FEM_LNA_Mode_NOT_PRESENT

--- a/src/mesh/generated/meshtastic/config.pb.h
+++ b/src/mesh/generated/meshtastic/config.pb.h
@@ -378,7 +378,7 @@ typedef enum _meshtastic_Config_LoRaConfig_ModemPreset {
     /* Short Range - Ultra
  Fastest preset with 500kHz bandwidth, SF5, and CR 4/5.
  Intended data rate is about 62.5 kbps.
- Only compatible with SX126x and LR11xx chipsets. */
+ Only compatible with SX126x-family chipsets, including STM32WLx, and LR11xx chipsets. */
     meshtastic_Config_LoRaConfig_ModemPreset_SHORT_ULTRA = 16
 } meshtastic_Config_LoRaConfig_ModemPreset;
 

--- a/test/test_radio/test_main.cpp
+++ b/test/test_radio/test_main.cpp
@@ -200,6 +200,46 @@ static void test_applyModemConfig_customCodingRateLowerThanPreset()
     TEST_ASSERT_EQUAL_UINT8(8, testRadio->getCr());
 }
 
+static void test_applyModemConfig_shortUltraParams()
+{
+    radioType = SX1262_RADIO;
+    config.lora = meshtastic_Config_LoRaConfig_init_zero;
+    config.lora.region = meshtastic_Config_LoRaConfig_RegionCode_US;
+    config.lora.use_preset = true;
+    config.lora.modem_preset = meshtastic_Config_LoRaConfig_ModemPreset_SHORT_ULTRA;
+
+    testRadio->reconfigure();
+
+    TEST_ASSERT_EQUAL_UINT8(5, testRadio->getCr());
+    TEST_ASSERT_EQUAL_UINT8(5, testRadio->getSf());
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, 500.0f, testRadio->getBw());
+}
+
+static void test_validateConfigLora_shortUltraHardwareGate()
+{
+    meshtastic_Config_LoRaConfig cfg = meshtastic_Config_LoRaConfig_init_zero;
+    cfg.use_preset = true;
+    cfg.region = meshtastic_Config_LoRaConfig_RegionCode_US;
+    cfg.modem_preset = meshtastic_Config_LoRaConfig_ModemPreset_SHORT_ULTRA;
+
+    radioType = RF95_RADIO;
+    TEST_ASSERT_FALSE(RadioInterface::validateConfigLora(cfg));
+
+    radioType = LR1110_RADIO;
+    TEST_ASSERT_TRUE(RadioInterface::validateConfigLora(cfg));
+}
+
+static void test_validateConfigLora_shortUltraNotWideLora()
+{
+    meshtastic_Config_LoRaConfig cfg = meshtastic_Config_LoRaConfig_init_zero;
+    cfg.use_preset = true;
+    cfg.region = meshtastic_Config_LoRaConfig_RegionCode_LORA_24;
+    cfg.modem_preset = meshtastic_Config_LoRaConfig_ModemPreset_SHORT_ULTRA;
+
+    radioType = LR1121_RADIO;
+    TEST_ASSERT_FALSE(RadioInterface::validateConfigLora(cfg));
+}
+
 // -----------------------------------------------------------------------
 // getRegionPresetMap() — region->valid-preset map sent to clients during want_config
 // -----------------------------------------------------------------------
@@ -281,10 +321,49 @@ static void test_regionPresetMap_matchesRegionTable()
     }
 }
 
+static int findPresetGroup(const meshtastic_LoRaRegionPresetMap &map, meshtastic_Config_LoRaConfig_RegionCode region)
+{
+    for (pb_size_t i = 0; i < map.region_groups_count; i++) {
+        if (map.region_groups[i].region == region)
+            return map.region_groups[i].group_index;
+    }
+    return -1;
+}
+
+static bool groupHasPreset(const meshtastic_LoRaPresetGroup &grp, meshtastic_Config_LoRaConfig_ModemPreset preset)
+{
+    for (pb_size_t p = 0; p < grp.presets_count; p++) {
+        if (grp.presets[p] == preset)
+            return true;
+    }
+    return false;
+}
+
+static void test_regionPresetMap_filtersShortUltraByRadioAndRegion()
+{
+    meshtastic_LoRaRegionPresetMap map;
+
+    radioType = SX1262_RADIO;
+    getRegionPresetMap(map);
+    int usGroup = findPresetGroup(map, meshtastic_Config_LoRaConfig_RegionCode_US);
+    int lora24Group = findPresetGroup(map, meshtastic_Config_LoRaConfig_RegionCode_LORA_24);
+    TEST_ASSERT_TRUE(usGroup >= 0);
+    TEST_ASSERT_TRUE(lora24Group >= 0);
+    TEST_ASSERT_TRUE(groupHasPreset(map.groups[usGroup], meshtastic_Config_LoRaConfig_ModemPreset_SHORT_ULTRA));
+    TEST_ASSERT_FALSE(groupHasPreset(map.groups[lora24Group], meshtastic_Config_LoRaConfig_ModemPreset_SHORT_ULTRA));
+
+    radioType = RF95_RADIO;
+    getRegionPresetMap(map);
+    usGroup = findPresetGroup(map, meshtastic_Config_LoRaConfig_RegionCode_US);
+    TEST_ASSERT_TRUE(usGroup >= 0);
+    TEST_ASSERT_FALSE(groupHasPreset(map.groups[usGroup], meshtastic_Config_LoRaConfig_ModemPreset_SHORT_ULTRA));
+}
+
 void setUp(void)
 {
     mockMeshService = new MockMeshService();
     service = mockMeshService;
+    radioType = NO_RADIO;
 
     // RadioInterface computes slotTimeMsec during construction and expects myRegion to be valid.
     config.lora.region = meshtastic_Config_LoRaConfig_RegionCode_US;
@@ -299,6 +378,7 @@ void tearDown(void)
     service = nullptr;
     delete mockMeshService;
     mockMeshService = nullptr;
+    radioType = NO_RADIO;
 }
 
 void setup()
@@ -322,8 +402,12 @@ void setup()
     RUN_TEST(test_applyModemConfig_codingRateMatchesPreset);
     RUN_TEST(test_applyModemConfig_customCodingRateHigherThanPreset);
     RUN_TEST(test_applyModemConfig_customCodingRateLowerThanPreset);
+    RUN_TEST(test_applyModemConfig_shortUltraParams);
+    RUN_TEST(test_validateConfigLora_shortUltraHardwareGate);
+    RUN_TEST(test_validateConfigLora_shortUltraNotWideLora);
     RUN_TEST(test_regionPresetMap_coversAllRegionsWithinBounds);
     RUN_TEST(test_regionPresetMap_matchesRegionTable);
+    RUN_TEST(test_regionPresetMap_filtersShortUltraByRadioAndRegion);
     exit(UNITY_END());
 }
 

--- a/test/test_radio/test_main.cpp
+++ b/test/test_radio/test_main.cpp
@@ -225,6 +225,12 @@ static void test_validateConfigLora_shortUltraHardwareGate()
     radioType = RF95_RADIO;
     TEST_ASSERT_FALSE(RadioInterface::validateConfigLora(cfg));
 
+    radioType = NO_RADIO;
+    TEST_ASSERT_FALSE(RadioInterface::validateConfigLora(cfg));
+
+    radioType = STM32WLx_RADIO;
+    TEST_ASSERT_TRUE(RadioInterface::validateConfigLora(cfg));
+
     radioType = LR1110_RADIO;
     TEST_ASSERT_TRUE(RadioInterface::validateConfigLora(cfg));
 }
@@ -301,15 +307,15 @@ static void test_regionPresetMap_matchesRegionTable()
         const size_t maxPresets = sizeof(grp.presets) / sizeof(grp.presets[0]);
         TEST_ASSERT_GREATER_THAN_UINT(0, grp.presets_count);
         TEST_ASSERT_LESS_OR_EQUAL_UINT((unsigned)maxPresets, grp.presets_count);
-        TEST_ASSERT_EQUAL_UINT((unsigned)r->getNumPresets(), (unsigned)grp.presets_count);
+        TEST_ASSERT_EQUAL_UINT((unsigned)r->getNumPresets(true), (unsigned)grp.presets_count);
 
         // Every advertised preset is legal in this region.
         for (pb_size_t p = 0; p < grp.presets_count; p++)
-            TEST_ASSERT_TRUE(r->supportsPreset(grp.presets[p]));
+            TEST_ASSERT_TRUE(r->supportsPreset(grp.presets[p], true));
 
         // Default preset matches the table, is legal, and is present in the list.
         TEST_ASSERT_EQUAL(r->getDefaultPreset(), grp.default_preset);
-        TEST_ASSERT_TRUE(r->supportsPreset(grp.default_preset));
+        TEST_ASSERT_TRUE(r->supportsPreset(grp.default_preset, true));
         bool defaultInList = false;
         for (pb_size_t p = 0; p < grp.presets_count; p++)
             if (grp.presets[p] == grp.default_preset)
@@ -352,11 +358,23 @@ static void test_regionPresetMap_filtersShortUltraByRadioAndRegion()
     TEST_ASSERT_TRUE(groupHasPreset(map.groups[usGroup], meshtastic_Config_LoRaConfig_ModemPreset_SHORT_ULTRA));
     TEST_ASSERT_FALSE(groupHasPreset(map.groups[lora24Group], meshtastic_Config_LoRaConfig_ModemPreset_SHORT_ULTRA));
 
+    radioType = STM32WLx_RADIO;
+    getRegionPresetMap(map);
+    usGroup = findPresetGroup(map, meshtastic_Config_LoRaConfig_RegionCode_US);
+    TEST_ASSERT_TRUE(usGroup >= 0);
+    TEST_ASSERT_TRUE(groupHasPreset(map.groups[usGroup], meshtastic_Config_LoRaConfig_ModemPreset_SHORT_ULTRA));
+
     radioType = RF95_RADIO;
     getRegionPresetMap(map);
     usGroup = findPresetGroup(map, meshtastic_Config_LoRaConfig_RegionCode_US);
     TEST_ASSERT_TRUE(usGroup >= 0);
     TEST_ASSERT_FALSE(groupHasPreset(map.groups[usGroup], meshtastic_Config_LoRaConfig_ModemPreset_SHORT_ULTRA));
+
+    radioType = NO_RADIO;
+    getRegionPresetMap(map);
+    usGroup = findPresetGroup(map, meshtastic_Config_LoRaConfig_RegionCode_US);
+    TEST_ASSERT_TRUE(usGroup >= 0);
+    TEST_ASSERT_TRUE(groupHasPreset(map.groups[usGroup], meshtastic_Config_LoRaConfig_ModemPreset_SHORT_ULTRA));
 }
 
 void setUp(void)


### PR DESCRIPTION
## Summary
- Add the `SHORT_ULTRA` modem preset surface to the generated firmware header, display names, standard preset list, and MCP userprefs allow-list.
- Configure ShortUltra as SF5, 500 kHz bandwidth, CR 4/5.
- Gate ShortUltra to sub-GHz SX126x-family radios, including STM32WLx, and LR11xx radios; keep it out of wide-LoRa / 2.4 GHz regions.
- Split region preset-map groups by the compatibility-filtered preset list so clients do not see ShortUltra in unsupported regions or on unsupported radios.
- Fix preset UI menus to iterate the full sentinel-terminated preset list and skip unsupported presets, rather than slicing `getAvailablePresets()` with a filtered count.
- Avoid hiding ShortUltra from client preset maps while radio probing is still unknown (`NO_RADIO`), while keeping strict runtime validation for actual config writes.

## Protobuf note
This firmware PR still carries the generated enum surface needed for C++ builds. The protobuf source-of-truth change is split into the companion draft PR:

- https://github.com/meshtastic/protobufs/pull/965

That PR adds `SHORT_ULTRA = 16` to `Config.LoRaConfig.ModemPreset` and updates the source comment. Regenerating from that protobuf branch produces the generated header used here. This firmware PR intentionally does not point the submodule at the fork commit; after the protobuf PR merges, the firmware branch should update the submodule pointer to the upstream protobuf commit.

## RF notes

| Item | Finding |
| --- | --- |
| Chip support | SF5 with 500 kHz LoRa bandwidth is in the SX126x-family and LR11xx capability set. SX127x/RF95 is intentionally excluded. |
| STM32WLx | STM32WLx uses the SX126x-style interface in firmware and is now allowed for ShortUltra. |
| Preamble | Semtech guidance for SF5/SF6 points to a longer preamble; the existing sub-GHz firmware default is 16 symbols, which satisfies the 12-symbol recommendation without a ShortUltra-specific code path. |
| Region exposure | ShortUltra is appended only to the standard sub-GHz preset list. EU_868, lite, narrow, tiny, and LORA_24 profiles do not expose it. |
| Default US center | With the default synthesized channel name `ShortUltra`, the US default lands at 902.750 MHz, using a 500 kHz channel from about 902.500 to 903.000 MHz. |
| Common defaults checked | The default does not overlap the common Meshtastic US defaults checked: LongFast 906.875 MHz, LongTurbo 908.750 MHz, ShortTurbo 926.750 MHz. It also avoids the current MeshCore US/Canada recommendation found, 910.525 MHz at BW 62.5 kHz. |
| Caveat | Manual `channel_num`, channel name, or frequency override can still create overlap. This change only keeps the default `ShortUltra` placement away from regularly used defaults. |

Sources reviewed for the draft notes:
- [Semtech SX1262 datasheet](https://cdn.sparkfun.com/assets/6/b/5/1/4/SX1262_datasheet.pdf)
- [Semtech LR1110 user manual](https://www.mouser.com/pdfDocs/UM_LR1110_W_APP_V10.pdf?srsltid=AfmBOookewFEW6kqWXPSzHwc_a5iLk9hCCNqxdKvuRX0GwWRlVHfxTxk)
- [Semtech LR1121 datasheet](https://files.waveshare.com/wiki/Core1121/LR1121_H2_DS_v2_0.pdf)
- [RadioLib SX126x parameter docs](https://jgromes.github.io/RadioLib/class_s_x126x.html)
- [Meshtastic radio settings docs](https://meshtastic.org/docs/overview/radio-settings/)
- [MeshCore FAQ/current docs](https://raw.githubusercontent.com/meshcore-dev/MeshCore/main/docs/faq.md)

## Rate shape

Nominal LoRa bit rate uses `SF * BW / 2^SF * CR`, with CR 4/5 represented as `0.8` here. Whole-packet airtime still depends on payload, header, CRC, and preamble.

| Preset | SF | BW | CR | Symbol time | Nominal bit rate | ShortUltra rate gain |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| LongFast | 11 | 250 kHz | 4/5 | 8.192 ms | 1.07 kbps | 58.2x |
| ShortTurbo | 7 | 500 kHz | 4/5 | 0.256 ms | 21.88 kbps | 2.86x |
| ShortUltra | 5 | 500 kHz | 4/5 | 0.064 ms | 62.50 kbps | 1.0x |

```mermaid
flowchart LR
    A["LoRa config requests SHORT_ULTRA"] --> B["Region supports standard sub-GHz presets"]
    B --> C["Radio type is SX126x-family, including STM32WLx, or LR11xx"]
    C --> D["Apply SF5 / BW500 / CR 4/5"]
    B --> E["Unsupported region"]
    C --> F["Unsupported radio"]
    E --> G["Reject or omit from client preset map"]
    F --> G
```

## Fast-lane follow-up plan

A low-loss automatic switch should be a router fast lane, not a wholesale client migration:

1. Keep client traffic on the existing preset and channel.
2. Add a router capability bit for ShortUltra support and a negotiated fast-lane channel slot.
3. Have routers probe ShortUltra peer links with short signed/counted control frames before promoting a route.
4. Use a deterministic superframe: most time stays on the client preset, with brief router-only ShortUltra windows on either an adjacent frequency slot or a configured secondary channel.
5. Demote immediately on missed probes or queue growth, and drain queued client traffic on the baseline preset.

That keeps clients compatible, bounds packet loss during transitions, and lets router-to-router backhaul use the faster preset where the RF link is strong enough. It needs a separate wire/config design because the clean version requires capability advertisement, channel/frequency guardrails, and scheduler changes.

```mermaid
sequenceDiagram
    participant C as Client preset
    participant R1 as Router A
    participant R2 as Router B
    participant F as ShortUltra lane
    C->>R1: Normal client traffic
    R1->>R2: Capability advertises ShortUltra support
    R1->>F: Probe window
    F->>R2: Signed/counting probe
    R2-->>R1: Probe result
    R1->>F: Promote queued router backhaul
    R1->>C: Return to client preset window
```

## Validation
- `trunk fmt` on the touched firmware files.
- `git diff --check`.
- `./bin/regen-protos.sh` completed with nanopb 0.4.9.1 against the companion protobuf branch.
- `~/.platformio/penv/bin/python -m platformio test -e native-macos -f test_radio` passed: 19/19.
- `~/.platformio/penv/bin/python -m platformio run -e heltec-v4` passed.
- `~/.platformio/penv/bin/python -m platformio run -e mini-epaper-s3-inkhud` passed.
- `platformio run -e rak4631` was previously run by a parallel worker and passed.
- `./bin/run-tests.sh -f test_radio` remains blocked on this macOS shell by `mapfile` and GNU `find -printf` assumptions.
- Raw `platformio test -e native -f test_radio` still does not reach tests on this macOS host because the current native build stops in unrelated `LinuxInput*` and `NotificationRenderer.cpp` sources.

## Hardware validation
- `platformio run -e heltec-v4 -t erase`, `upload`, and `uploadfs` passed on both attached Heltec V4s:
  - `/dev/cu.usbmodem3101`, MAC `f8:5b:1b:be:d3:08`
  - `/dev/cu.usbmodem83401`, MAC `f8:5b:1b:a5:a4:80`
- Both nodes reported `firmwareVersion: 2.8.0.98bf656` after the clean flash.
- Both nodes accepted `lora.region=US`, `lora.use_preset=true`, and `lora.modem_preset=16`; the installed Meshtastic CLI is older than the new enum name, so numeric `16` was used.
- Readback on both nodes reported `lora.region: 1`, `lora.use_preset: True`, and `lora.modem_preset: 16`.
- ShortUltra RF smoke test passed both directions:
  - `3101` -> `83401`: received `TEXT_MESSAGE_APP` payload `ShortUltra broadcast 2026-06-29` over `TRANSPORT_LORA`, SNR 6.75 dB, RSSI -30.
  - `83401` -> `3101`: received `TEXT_MESSAGE_APP` payload `ShortUltra reverse 2026-06-29` over `TRANSPORT_LORA`, SNR 8 dB.
- Reciprocal node tables also showed peer discovery at 8-9 dB SNR on channel 0.

## Hardware note
A direct encrypted DM ACK was not used as the pass/fail signal. The first attempt ran before public-key exchange and returned `PKI_SEND_FAIL_PUBLIC_KEY`; a later ACK retry returned `MAX_RETRANSMIT`. Plain channel traffic and peer discovery over ShortUltra passed in both directions.
